### PR TITLE
Time to build Scheduler

### DIFF
--- a/fx/bist.to2
+++ b/fx/bist.to2
@@ -78,6 +78,17 @@ impl Bist {
         }
     }
 
+    sync fn assert_string(self, name: string, expected: string, observed: string) -> BistResult = {
+        if (observed == expected) {
+            self.pass(name)
+        } else {
+            self.add_fail_head(name, "string does not match")
+                .add("observed: " + observed)
+                .add("expected: " + expected)
+                .add_fail_tail(name)
+        }
+    }
+
     sync fn clear(self) -> Bist = {
         self.test_count = 0
         self.fail_count = 0

--- a/fx/bist_bist.to2
+++ b/fx/bist_bist.to2
@@ -165,6 +165,17 @@ fn test_bist_assert_int(bist: Bist, name: string) -> BistResult = {
     bist.summary(name)
 }
 
+fn test_bist_assert_string(bist: Bist, name: string) -> BistResult = {
+
+    test_bist_reports_pass(bist, name + " PASS check",
+        fn(inner_bist, name) -> inner_bist.assert_string(name, "correct-string", "correct-string"))
+
+    test_bist_reports_fail(bist, name + " FAIL check",
+        fn(inner_bist, name) -> inner_bist.assert_string(name, "correct-string", "not-correct-string"))
+
+    bist.summary(name)
+}
+
 fn test_bist(bist: Bist, name: string) -> BistResult = {
 
     // Note: yes, we are testing the test code.
@@ -176,6 +187,7 @@ fn test_bist(bist: Bist, name: string) -> BistResult = {
     test_bist_assert_true(bist, name + " assert_true")
     test_bist_assert_false(bist, name + " assert_false")
     test_bist_assert_float(bist, name + " assert_float")
+    test_bist_assert_string(bist, name + " assert_string")
 
     bist.summary(name)
 }

--- a/fx/log.to2
+++ b/fx/log.to2
@@ -18,12 +18,17 @@ struct LogLine(text: string) {
 pub struct Log {
     top : Option<LogLine> = noLine
     end : Option<LogLine> = noLine
+    count : int = 0
 }
 
 impl Log {
+    sync fn lines(self) -> int = {
+        self.count
+    }
     sync fn clear(self) -> Log = {
         self.top = noLine
         self.end = noLine
+        self.count = 0
         self
     }
     sync fn empty(self) -> bool = {
@@ -35,6 +40,7 @@ impl Log {
         if (self.end.defined) self.end.value.next = bllr
         if (!self.top.defined) self.top = bllr
         self.end = bllr
+        self.count += 1
         self
     }
     sync fn pop(self) -> Option<string> = {
@@ -44,6 +50,7 @@ impl Log {
         } else {
             const ll = self.top.value
             self.top = ll.next
+            self.count -= 1
             Some(ll.text)
         }
     }

--- a/fx/scheduler.to2
+++ b/fx/scheduler.to2
@@ -1,0 +1,112 @@
+use { Vessel } from ksp::vessel
+use { CONSOLE } from ksp::console
+
+use { sleep, current_time } from ksp::game
+
+use { Common } from fx::common
+
+type SchTaskFunc = fn() -> float
+
+type SchTaskRef = Option<SchTask>
+
+pub struct Scheduler {
+    next : SchTaskRef = make_last_sch_task()
+    name : string = ""
+}
+
+// TODO: Scheduler::add(name, when, task) adds the task to the schedule.
+// TODO: Scheduler::step() runs the task if it is time to do so, then reschedules it.
+
+sync fn sch_insert(sch: Scheduler, node: SchTask) -> Unit = {
+
+    if (!sch.next.defined) {
+        // safety net (should never happen)
+        sch.next = Some(node)
+        return
+    }
+
+    if (node.when < sch.next.value.when) {
+        // expected common case: inserting at the head of the list
+        node.next = sch.next
+        sch.next = Some(node)
+        return
+    }
+
+    // insert into the list after all nodes
+    // whose scheduled times are earlier or the same.
+    let t1 = sch.next.value
+    while (t1.next.defined) {
+        let t2 = t1.next.value
+        if (node.when < t2.when) {
+            break
+        }
+        t1 = t2
+    }
+
+    node.next = t1.next
+    t1.next = Some(node)
+}
+
+sync fn sch_remove(sch: Scheduler) -> SchTaskRef = {
+    const result = sch.next
+    if (result.defined)
+        sch.next = result.value.next
+    result
+}
+
+impl Scheduler {
+    sync fn next_when(self) -> float = { self.next.value.when }
+    sync fn next_name(self) -> string = { self.next.value.name }
+    sync fn next_task(self) -> SchTaskFunc = { self.next.value.task }
+
+    sync fn add(self, eta: float, name: string, task: SchTaskFunc) -> Unit = {
+        sch_insert(self, SchTask(eta, name, task))
+    }
+
+    fn step(self) -> Unit = {
+
+        if (current_time() < self.next_when()) {
+            return
+        }
+
+        const r : SchTaskRef = sch_remove(self)
+        if (!r.defined) {
+            return
+        }
+
+        if (self.name != r.value.name) {
+            self.name = r.value.name
+        }
+
+        let dt = r.value.task()
+        if (dt > 0.0) {
+            r.value.when = current_time() + dt
+            sch_insert(self, r.value)
+        }
+    }
+
+    fn loop(self) -> Unit = {
+        while (self.next_when() < NEVER) {
+            self.step()
+            sleep(0.0)
+        }
+    }
+}
+
+pub const NEVER : float = 1.0 / 0.0         // yes, Infinity.
+
+// oddity in KontrolSystem2 0.2.2.0
+// this initializer was not working:
+//    next: SchTaskRef = None()
+const noSchTaskRef : SchTaskRef = None()
+
+struct SchTask(eta: float, name: string, task: SchTaskFunc) {
+    next : SchTaskRef = noSchTaskRef
+    when : float = eta + current_time()
+    name : string = name
+    task : SchTaskFunc = task
+}
+
+sync fn make_last_sch_task() -> SchTaskRef = {
+    SchTask(NEVER, "never", fn() -> NEVER)
+}

--- a/fx/scheduler_bist.to2
+++ b/fx/scheduler_bist.to2
@@ -1,0 +1,150 @@
+use { Vessel } from ksp::vessel
+use { CONSOLE } from ksp::console
+
+use { sleep, current_time } from ksp::game
+
+use { Common } from fx::common
+use { Log } from fx::log
+
+use { Bist, BistResult } from fx::bist
+
+use { Scheduler, NEVER } from fx::scheduler
+
+fn test_sch_init(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
+    bist.assert_true(name + " sch has initial NEVER task", sch.next.defined)?
+    bist.assert_float(name + " never-task scheduled time", NEVER, NEVER, sch.next_when())?
+    bist.assert_string(name + " never-task name", "never", sch.next_name())?
+
+    bist.summary(name)
+}
+
+fn test_sch_once(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
+    const t0 = current_time()
+    sch.add(0.1, "once", fn() -> 0.0)
+
+    bist.assert_float(name + " once-task scheduled time", t0+0.09, t0+0.11, sch.next_when())?
+    bist.assert_string(name + " once-task name", "once", sch.next_name())?
+
+    let t2 = sch.next_task()
+    bist.assert_float(name + " once-task return value", 0.0, 0.0, t2())?
+
+    sch.step()
+    bist.assert_string(name + " once-task still pending", "once", sch.next_name())?
+
+    sch.step()
+    bist.assert_string(name + " once-task still pending", "once", sch.next_name())?
+
+    sleep(0.15)
+
+    sch.step()
+    bist.assert_string(name + " once-task no longer pending", "never", sch.next_name())?
+
+    bist.summary(name)
+}
+
+fn test_sch_twice(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
+    const t0 = current_time()
+    sch.add(0.10, "twice", fn() -> 0.1)
+
+    bist.assert_float(name + " twice-task scheduled time", t0+0.09, t0+0.11, sch.next_when())?
+    bist.assert_string(name + " twice-task name", "twice", sch.next_name())?
+
+    let t2 = sch.next_task()
+    bist.assert_float(name + " twice-task return value", 0.1, 0.1, t2())?
+
+    let t2when = sch.next_when()
+
+    sch.step()
+    bist.assert_string(name + " twice-task still pending", "twice", sch.next_name())?
+    bist.assert_float(name + " twice-task same schedule", t2when, t2when, sch.next_when())?
+
+    sch.step()
+    bist.assert_string(name + " twice-task still pending", "twice", sch.next_name())?
+    bist.assert_float(name + " twice-task same schedule", t2when, t2when, sch.next_when())?
+
+    sleep(0.11)
+    let t3 = current_time()
+
+    sch.step()
+    bist.assert_string(name + " twice-task still pending", "twice", sch.next_name())?
+    bist.assert_float(name + " twice-task second schedule", t3+0.10, t3+0.20, sch.next_when())?
+    let t3when = sch.next_when()
+
+    sch.step()
+    bist.assert_string(name + " twice-task still pending", "twice", sch.next_name())?
+    bist.assert_float(name + " twice-task second schedule", t3when, t3when, sch.next_when())?
+
+    sch.next = sch.next.value.next
+    bist.assert_string(name + " twice-task no longer pending", "never", sch.next_name())?
+
+    bist.summary(name)
+}
+
+fn test_sch_fizzbuzz(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
+    const log : Log = Log()
+
+    sch.add(0.3, "fizz", fn() -> {
+        if (log.lines() > 4) return 0.0
+        log.add("fizz")
+        0.3
+    })
+
+    sch.add(0.5, "buzz", fn() -> {
+        if (log.lines() > 4) return 0.0
+        log.add("buzz")
+        0.5
+    })
+
+    sch.loop()
+
+    bist.assert_string(name + " log entry 1 ", "fizz", log.pop().value)
+    bist.assert_string(name + " log entry 2 ", "buzz", log.pop().value)
+    bist.assert_string(name + " log entry 3 ", "fizz", log.pop().value)
+    bist.assert_string(name + " log entry 4 ", "fizz", log.pop().value)
+    bist.assert_string(name + " log entry 5 ", "buzz", log.pop().value)
+
+    bist.summary(name)
+}
+
+fn test_scheduler(bist: Bist, name: string) -> BistResult = {
+
+    // Note: bist.assert_*()? calls (with a trailing ?)
+    // indicate that if that case fails, do nothing more
+    // in this set of cases, returning the failure upward.
+
+    // A fresh scheduler will report that the next pending
+    // task happens NEVER, and if we call it, it returns
+    // a duration that will be reached NEVER.
+
+    const sch = Scheduler()
+    test_sch_init(bist, name + " init", sch)?
+    test_sch_once(bist, name + " once", sch)?
+    test_sch_twice(bist, name + " twice", sch)?
+    test_sch_fizzbuzz(bist, name + " fizzbuzz", sch)?
+
+    bist.summary(name)
+}
+
+pub fn main_flight(vessel: Vessel) -> Result<Unit, string> = {
+    CONSOLE.clear()
+
+    const t0 = current_time()
+    CONSOLE.print_line("BIST of SCHEDULER starts at " + t0.to_string())
+
+    const bist = Bist()
+    let result = test_scheduler(bist, "scheduler")
+    let dt = current_time() - t0
+
+    if (result.success) {
+        CONSOLE.print_line("  " + result.value)
+        CONSOLE.print_line("PASS elapsed time " + dt.to_string())
+    } else {
+        CONSOLE.print_line("  " + result.error)
+        CONSOLE.print_line("FAIL elapsed time " + dt.to_string())
+        CONSOLE.print_line("")
+        CONSOLE.print_line("full bist log ...")
+        bist.print()
+        CONSOLE.print_line("full bist log done")
+        CONSOLE.print_line("")
+    }
+}


### PR DESCRIPTION
Fixes #22

Create the scheduler class.
- inernal insert and remove methods keep it sorted
- export next_when, next_name, next_task
- export Scheduler::add, step, loop
- export NEVER time constant

provide scheduler test code.

support changes:
- added Log::count and Log::lines()
- added Bist::assert_string()
- added test code for Bist::assert_string