### PR TITLE
Farsyte/issue29

### DIFF
--- a/fx/all_bist.to2
+++ b/fx/all_bist.to2
@@ -1,0 +1,34 @@
+use { CONSOLE } from ksp::console
+use { Vessel } from ksp::vessel
+
+use { Bist } from fx::bist
+
+use { log_test } from fx::log_bist
+use { bist_test } from fx::bist_bist
+use { scheduler_bist } from fx::scheduler_bist
+
+pub fn all_test(bist: Bist) -> Result<Unit, string> = {
+    log_test()?
+    bist_test(bist)?
+    scheduler_bist(bist)?
+}
+
+pub fn main_flight(vessel: Vessel) -> Result<Unit, string> = {
+    CONSOLE.clear()
+
+    const bist = Bist()
+
+    const result = all_test(bist)
+
+    if (result.success) {
+        CONSOLE.print_line("PASS all_test")
+    } else {
+        CONSOLE.print_line("")
+        CONSOLE.print_line("full bist log ...")
+        bist.print()
+        CONSOLE.print_line("full bist log done")
+        CONSOLE.print_line("")
+        CONSOLE.print_line("FAIL " + result.error)
+        Err(result.error)
+    }
+}

--- a/fx/bist_bist.to2
+++ b/fx/bist_bist.to2
@@ -86,8 +86,12 @@ fn test_bist_log_quickly(name: string) -> BistResult = {
         .add("bist log test line one")
         .add("bist log test line two")
 
+    CONSOLE.print_line("")
+    CONSOLE.print_line("vvvvv MANUAL CHECK REQUIRED vvvvv")
     CONSOLE.print_line("please check manually that this prints the two lines")
     bist.print()
+    CONSOLE.print_line("^^^^^ MANUAL CHECK REQUIRED ^^^^^")
+    CONSOLE.print_line("")
 
     if (bist.empty()) return Err(name + " FAIL: bist log empty, should have two lines")
     const l1 = bist.pop()
@@ -200,27 +204,30 @@ fn test_bist(bist: Bist, name: string) -> BistResult = {
 // stable configuration (landed, in orbit, on a long
 // trajectory to elsewhere, etc).
 
-pub fn main_flight(vessel: Vessel) -> Result<Unit, string> = {
-    CONSOLE.clear()
+// pub fn main_flight(vessel: Vessel) -> Result<Unit, string> = {
+//     CONSOLE.clear()
+//
+//     const bist = Bist()
+//     const result = bist_test(bist)
+//
+//     if (result.success) {
+//     } else {
+//         CONSOLE.print_line("")
+//         CONSOLE.print_line("full bist log ...")
+//         bist.print()
+//         CONSOLE.print_line("full bist log done")
+//         CONSOLE.print_line("")
+//         Err(result.error)
+//     }
+// }
 
-    const t0 = current_time()
-    CONSOLE.print_line("BIST of BIST starts at " + t0.to_string())
-
-    const bist = Bist()
+pub fn bist_test(bist: Bist) -> Result<Unit, string> = {
     let result = test_bist(bist, "bist")
-    let dt = current_time() - t0
-
-    CONSOLE.print_line("")
-    CONSOLE.print_line("full bist log ...")
-    bist.print()
-    CONSOLE.print_line("full bist log done")
-    CONSOLE.print_line("")
 
     if (result.success) {
-        CONSOLE.print_line("PASS elapsed time " + dt.to_string())
-        CONSOLE.print_line("   " + result.value)
+        CONSOLE.print_line("PASS " + result.value)
     } else {
-        CONSOLE.print_line("FAIL elapsed time " + dt.to_string())
-        CONSOLE.print_line("   " + result.error)
+        CONSOLE.print_line("FAIL " + result.error)
+        Err(result.error)
     }
 }

--- a/fx/log_bist.to2
+++ b/fx/log_bist.to2
@@ -20,8 +20,12 @@ fn test_log_quickly(name: string) -> Result<string, string> = {
         .add("Log test line one")
         .add("Log test line two")
 
+    CONSOLE.print_line("")
+    CONSOLE.print_line("vvvvv MANUAL CHECK REQUIRED vvvvv")
     CONSOLE.print_line("please check manually that this prints the two lines")
     log.print()
+    CONSOLE.print_line("^^^^^ MANUAL CHECK REQUIRED ^^^^^")
+    CONSOLE.print_line("")
 
     if (log.empty()) return Err(name + " FAIL: log empty, should have two lines")
     const l1 = log.pop()
@@ -42,22 +46,20 @@ fn test_log_quickly(name: string) -> Result<string, string> = {
 
 // ======== below here is stuff used only for doing BIST of LOG ========
 
-pub fn main_flight(vessel: Vessel) -> Result<Unit, string> = {
-    CONSOLE.clear()
+// pub fn main_flight(vessel: Vessel) -> Result<Unit, string> = {
+//     CONSOLE.clear()
+//     log_test()?
+//     // open for extension: add more test calls here.
+// }
 
-    const t0 = current_time()
-    CONSOLE.print_line("BIST of LOG starts at " + t0.to_string())
 
+pub fn log_test() -> Result<Unit, string> = {
     let result = test_log_quickly("Log quick test")
-    // NOTE: if the above test succeeds, we can create a Bist
-    // and use it to test the more
 
-    let dt = current_time() - t0
     if (result.success) {
-        CONSOLE.print_line("PASS elapsed time " + dt.to_string())
-        CONSOLE.print_line("   " + result.value)
+        CONSOLE.print_line("PASS: " + result.value)
     } else {
-        CONSOLE.print_line("FAIL elapsed time " + dt.to_string())
-        CONSOLE.print_line("   " + result.error)
+        CONSOLE.print_line("FAIL: " + result.error)
+        Err(result.error)
     }
 }

--- a/fx/scheduler_bist.to2
+++ b/fx/scheduler_bist.to2
@@ -125,26 +125,32 @@ fn test_scheduler(bist: Bist, name: string) -> BistResult = {
     bist.summary(name)
 }
 
-pub fn main_flight(vessel: Vessel) -> Result<Unit, string> = {
-    CONSOLE.clear()
+// pub fn main_flight(vessel: Vessel) -> Result<Unit, string> = {
+//     CONSOLE.clear()
+//
+//     const bist : Bist = Bist()
+//     const result = scheduler_bist(bist)
+//     if (result.success) {
+//         CONSOLE.print_line("PASS scheduler_bist")
+//     } else {
+//         CONSOLE.print_line("")
+//         CONSOLE.print_line("full bist log ...")
+//         bist.print()
+//         CONSOLE.print_line("full bist log done")
+//         CONSOLE.print_line("")
+//         CONSOLE.print_line("FAIL " + result.error)
+//         Err(result.error)
+//     }
+// }
 
-    const t0 = current_time()
-    CONSOLE.print_line("BIST of SCHEDULER starts at " + t0.to_string())
+pub fn scheduler_bist(bist: Bist) -> Result<Unit, string> = {
 
-    const bist = Bist()
     let result = test_scheduler(bist, "scheduler")
-    let dt = current_time() - t0
 
     if (result.success) {
-        CONSOLE.print_line("  " + result.value)
-        CONSOLE.print_line("PASS elapsed time " + dt.to_string())
+        CONSOLE.print_line("PASS test_scheduler")
     } else {
-        CONSOLE.print_line("  " + result.error)
-        CONSOLE.print_line("FAIL elapsed time " + dt.to_string())
-        CONSOLE.print_line("")
-        CONSOLE.print_line("full bist log ...")
-        bist.print()
-        CONSOLE.print_line("full bist log done")
-        CONSOLE.print_line("")
+        CONSOLE.print_line("FAIL " + result.error)
+        Err(result.error)
     }
 }

--- a/tinker.to2
+++ b/tinker.to2
@@ -47,9 +47,33 @@ impl TinkerMission {
     }
 }
 
+fn tinker_bist(vessel: Vessel) -> Result<Unit, string> = {
+
+    CONSOLE.print_line("")
+    CONSOLE.print_line("Running BIST before staring ...")
+
+    const bist : fx::bist::Bist = fx::bist::Bist()
+    const result = fx::all_bist::all_test(bist)
+    if (result.success) {
+        CONSOLE.print_line("PASS all_bist")
+        CONSOLE.print_line("")
+    } else {
+        CONSOLE.print_line("")
+        CONSOLE.print_line("complete bist log ...")
+        bist.print()
+        CONSOLE.print_line("complete bist log ... done")
+        CONSOLE.print_line("")
+        CONSOLE.print_line("FAIL " + result.error)
+        CONSOLE.print_line("")
+        Err(result.error)
+    }
+}
+
 pub fn main_flight( vessel: Vessel, target_apoapsis: float = 80000.0, heading: float = 90.0 ) -> Result<Unit, string> = {
     CONSOLE.clear()
     CONSOLE.print_line("Hello from Vessel: " + vessel.name)
+
+    tinker_bist(vessel)
 
     const mission = TinkerMission(Common(vessel))
 


### PR DESCRIPTION
Fixes #29

test scripts now have a public entry point with a name
related to the test, so we can import many of them.

provide a script to run all the tests, same layout.

call the all-tester from tinker.