### PR TITLE
Split staging duties

### DIFF
--- a/fx/ascent.to2
+++ b/fx/ascent.to2
@@ -6,6 +6,7 @@ use { Common } from fx::common
 
 pub struct Ascent(common: Common) {
     common : Common = common
+
     mode : int = 0
     mode_met : float = 0.0
 
@@ -33,6 +34,8 @@ impl Ascent {
         if (self.mode != 3) {
             self.mode = 3
             self.mode_met = common.met()
+
+            CONSOLE.print_line("starting gravity turn")
 
             self.alt_min = vessel.altitude_sealevel
             self.alt_max = max(vessel.main_body.atmosphere_depth, self.alt_min + 1000)
@@ -66,6 +69,8 @@ impl Ascent {
         if (self.mode != 4) {
             self.mode = 4
             self.mode_met = common.met()
+
+            CONSOLE.print_line("coasting to space")
 
             common.t_mgr.throttle = 0.0
             vessel.autopilot.enabled = true

--- a/fx/common.to2
+++ b/fx/common.to2
@@ -30,7 +30,22 @@ pub struct Common(vessel: Vessel) {
 }
 
 impl Common {
+    sync fn stage_pending(self) -> bool = { self.sequencer.stage_pending() }
+    sync fn stage_request(self) -> Unit = { self.sequencer.stage_request() }
+    sync fn stage_cancel(self) -> Unit = { self.sequencer.stage_cancel() }
+
+    fn loop(self) -> Unit = {
+        self.sequencer.loop()
+    }
+
     sync fn met(self) -> float = {
         current_time() - self.t0
     }
+    sync fn run_at(self, eta: float, name: string, task: fn() -> float) -> Unit = {
+        self.sequencer.run_at(eta, name, task)
+    }
+    sync fn next_seq(self, task: fn() -> float) -> Unit = {
+        self.sequencer.next_seq(task)
+    }
+
 }

--- a/fx/launch.to2
+++ b/fx/launch.to2
@@ -8,6 +8,7 @@ use { Common } from fx::common
 
 pub struct Launch(common: Common) {
     common : Common = common
+
     mode : int = 0
     mode_ut : float = 0.0
 
@@ -74,6 +75,9 @@ impl Launch {
         if (self.mode != 2) {
             self.mode = 2
             self.mode_ut = t
+
+            CONSOLE.print_line("launching")
+
             self.liftoff_done_alt = vessel.altitude_sealevel + self.launch_height
             common.t0 = t       // this is the REAL T-0 universal time.
             common.t_mgr.throttle = 1.0

--- a/fx/orbital.to2
+++ b/fx/orbital.to2
@@ -11,6 +11,7 @@ use { Common } from fx::common
 
 pub struct Orbital(common: Common) {
     common : Common = common
+
     mode : int = 0
     // mode 0: nothing happening
     // mode 1: planned circ_ut burn
@@ -85,6 +86,8 @@ impl Orbital {
         vessel.autopilot.enabled = true
         vessel.autopilot.mode = MODE_PROGRADE
 
+        CONSOLE.print_line("circularization complete")
+
         0.0
     }
 
@@ -99,6 +102,8 @@ impl Orbital {
 
             self.mode = 2
             self.mode_met = met
+
+            CONSOLE.print_line("circularizing at AP")
 
             self.burn_ut = orbit.next_apoapsis_time(t + 30).value
 

--- a/fx/scheduler.to2
+++ b/fx/scheduler.to2
@@ -1,18 +1,16 @@
 use { Vessel } from ksp::vessel
 use { CONSOLE } from ksp::console
 
-use { sleep, current_time } from ksp::game
+use { yield, sleep, current_time } from ksp::game
 
 use { Common } from fx::common
-
-type SchTaskFunc = fn() -> float
-
-type SchTaskRef = Option<SchTask>
 
 pub struct Scheduler(vessel: Vessel) {
     vessel : Vessel = vessel
 
-    next : SchTaskRef = make_last_sch_task()
+    pend_stage : bool = false
+
+    next : Option<SchTask> = make_last_sch_task()
     name : string = ""
 }
 
@@ -46,7 +44,7 @@ sync fn sch_insert(sch: Scheduler, node: SchTask) -> Unit = {
     t1.next = Some(node)
 }
 
-sync fn sch_remove(sch: Scheduler) -> SchTaskRef = {
+sync fn sch_remove(sch: Scheduler) -> Option<SchTask> = {
     const result = sch.next
     if (result.defined)
         sch.next = result.value.next
@@ -54,21 +52,25 @@ sync fn sch_remove(sch: Scheduler) -> SchTaskRef = {
 }
 
 impl Scheduler {
+    sync fn stage_pending(self) -> bool = { self.pend_stage }
+    sync fn stage_request(self) -> Unit = { self.pend_stage = true }
+    sync fn stage_cancel(self) -> Unit = { self.pend_stage = false }
+
     sync fn next_when(self) -> float = { self.next.value.when }
     sync fn next_name(self) -> string = { self.next.value.name }
-    sync fn next_task(self) -> SchTaskFunc = { self.next.value.task }
+    sync fn next_task(self) -> fn() -> float = { self.next.value.task }
 
-    sync fn add(self, eta: float, name: string, task: SchTaskFunc) -> Unit = {
+    sync fn run_at(self, eta: float, name: string, task: fn() -> float) -> Unit = {
         sch_insert(self, SchTask(eta, name, task))
     }
 
-    fn step(self) -> Unit = {
+    sync fn step(self) -> Unit = {
 
         if (current_time() < self.next_when()) {
             return
         }
 
-        const r : SchTaskRef = sch_remove(self)
+        const r : Option<SchTask> = sch_remove(self)
         if (!r.defined) {
             return
         }
@@ -84,10 +86,27 @@ impl Scheduler {
         }
     }
 
+    fn async(self) -> Unit = {
+
+        if (self.stage_pending()) {
+            self.vessel.staging.next()
+            self.stage_cancel()
+        }
+
+    }
+
     fn loop(self) -> Unit = {
         while (self.next_when() < NEVER) {
             self.step()
-            sleep(0.0)
+            self.async()
+
+            // open for extension: we could decide to sleep
+            // for a bit, if it is important to conserve
+            // host CPU cycles. Would not want to sleep longer
+            // than the ETA of the next task, and probably would
+            // not want to sleep for a long time in any case.
+
+            yield()
         }
     }
 }
@@ -96,16 +115,16 @@ pub const NEVER : float = 1.0 / 0.0         // yes, Infinity.
 
 // oddity in KontrolSystem2 0.2.2.0
 // this initializer was not working:
-//    next: SchTaskRef = None()
-const noSchTaskRef : SchTaskRef = None()
+//    next: Option<SchTask> = None()
+const noSchTaskRef : Option<SchTask> = None()
 
-struct SchTask(eta: float, name: string, task: SchTaskFunc) {
-    next : SchTaskRef = noSchTaskRef
+struct SchTask(eta: float, name: string, task: fn() -> float) {
+    next : Option<SchTask> = noSchTaskRef
     when : float = eta + current_time()
     name : string = name
-    task : SchTaskFunc = task
+    task : fn() -> float = task
 }
 
-sync fn make_last_sch_task() -> SchTaskRef = {
+sync fn make_last_sch_task() -> Option<SchTask> = {
     SchTask(NEVER, "never", fn() -> NEVER)
 }

--- a/fx/scheduler_bist.to2
+++ b/fx/scheduler_bist.to2
@@ -20,7 +20,7 @@ fn test_sch_init(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
 
 fn test_sch_once(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
     const t0 = current_time()
-    sch.add(0.1, "once", fn() -> 0.0)
+    sch.run_at(0.1, "once", fn() -> 0.0)
 
     bist.assert_float(name + " once-task scheduled time", t0+0.09, t0+0.11, sch.next_when())?
     bist.assert_string(name + " once-task name", "once", sch.next_name())?
@@ -44,7 +44,7 @@ fn test_sch_once(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
 
 fn test_sch_twice(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
     const t0 = current_time()
-    sch.add(0.10, "twice", fn() -> 0.1)
+    sch.run_at(0.10, "twice", fn() -> 0.1)
 
     bist.assert_float(name + " twice-task scheduled time", t0+0.09, t0+0.11, sch.next_when())?
     bist.assert_string(name + " twice-task name", "twice", sch.next_name())?
@@ -83,13 +83,13 @@ fn test_sch_twice(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
 fn test_sch_fizzbuzz(bist: Bist, name: string, sch: Scheduler) -> BistResult = {
     const log : Log = Log()
 
-    sch.add(0.3, "fizz", fn() -> {
+    sch.run_at(0.3, "fizz", fn() -> {
         if (log.lines() > 4) return 0.0
         log.add("fizz")
         0.3
     })
 
-    sch.add(0.5, "buzz", fn() -> {
+    sch.run_at(0.5, "buzz", fn() -> {
         if (log.lines() > 4) return 0.0
         log.add("buzz")
         0.5

--- a/fx/sequencer.to2
+++ b/fx/sequencer.to2
@@ -3,35 +3,36 @@ use { CONSOLE } from ksp::console
 
 use { Scheduler } from fx::scheduler
 
-pub type float = float
-
-pub type SeqTask = fn() -> float
-
 pub struct Sequencer(vessel: Vessel) {
     scheduler: Scheduler = Scheduler(vessel)
 
-    next: NodeRef = no_node
-    last: NodeRef = no_node
+    next: Option<Node> = no_node
+    last: Option<Node> = no_node
     step: int = 0
 }
 
-type NodeRef = Option<Node>
-
-struct Node(task: SeqTask) {
-    next: NodeRef = no_node
-    task: SeqTask = task
+struct Node(task: fn() -> float) {
+    next: Option<Node> = no_node
+    task: fn() -> float = task
 }
 
 // oddity in KnotrolSystem2 0.2.2.0
 // this initializer was not working:
-//    next: NodeRef = None()
-const no_node : NodeRef = None()
+//    next: Option<Node> = None()
+const no_node : Option<Node> = None()
 
 impl Sequencer {
+    sync fn stage_pending(self) -> bool = { self.scheduler.stage_pending() }
+    sync fn stage_request(self) -> Unit = { self.scheduler.stage_request() }
+    sync fn stage_cancel(self) -> Unit = { self.scheduler.stage_cancel() }
 
-    fn add(self, task: SeqTask) -> Unit = {
-        const nref : NodeRef = Some(Node(task))
-        const last : NodeRef = self.last
+    sync fn run_at(self, eta: float, name: string, task: fn() -> float) -> Unit = {
+        self.scheduler.run_at(eta, name, task)
+    }
+
+    sync fn next_seq(self, task: fn() -> float) -> Unit = {
+        const nref : Option<Node> = Some(Node(task))
+        const last : Option<Node> = self.last
         if (!self.next.defined)
             self.next = nref
         if (self.last.defined)
@@ -39,7 +40,12 @@ impl Sequencer {
         self.last = nref
     }
 
-    fn step(self) -> float = {
+    fn loop(self) -> Unit = {
+        self.run_at(1.0, "seq", fn () -> self.step())
+        self.scheduler.loop()
+    }
+
+    sync fn step(self) -> float = {
         if (self.next.defined) {
             let n = self.next.value
             let r = n.task()

--- a/fx/stager.to2
+++ b/fx/stager.to2
@@ -1,46 +1,45 @@
 use { CONSOLE } from ksp::console
 use { Common } from fx::common
+
 pub struct Stager(common: Common) {
     common : Common = common
 }
+
+sync fn any_flameout(stager: Stager) -> bool = {
+    const common = stager.common
+    let parts = common.vessel.staging
+        .parts_in_stage(common.vessel.staging.current)
+    for (part in parts) {
+        if (part.is_engine && part.engine_module.defined) {
+            let eng = part.engine_module.value
+            if (eng.is_flameout)
+                return true
+        }
+    }
+    false
+}
+
+sync fn stage_needed(stager: Stager) -> bool = {
+    const common = stager.common
+    const vessel = common.vessel
+    const staging = vessel.staging
+
+    (1 < staging.current) &&
+    (0.0 <= common.met()) &&
+    ( (0.0 == vessel.available_thrust) ||
+        any_flameout(stager))
+}
+
 impl Stager {
-    fn count_flameout(self) -> int = {
-        const common = self.common
-        common.vessel.staging
-            .parts_in_stage(common.vessel.staging.current)
-            .filter(fn(part) -> part.is_engine)
-            .filter(fn(part) -> part.engine_module.defined)
-            .map(fn(part) -> part.engine_module.value)
-            .filter(fn(eng) -> eng.is_flameout)
-            .length
-    }
 
-    fn stage_needed(self) -> bool = {
-        const common = self.common
-        const vessel = common.vessel
-        const staging = vessel.staging
-
-        const s = staging.current
-        if (2 > staging.current) {
-            return false
+    sync fn stage_check(self) -> float = {
+        if (self.common.stage_pending()) {
+            1.0
+        } else if (stage_needed(self)) {
+            self.common.stage_request()
+            1.0
+        } else {
+            0.1
         }
-        const met = common.met()
-        if (0.0 > met) {
-            return false
-        }
-        const t = vessel.available_thrust
-        if (0.0 == t) {
-            return true
-        }
-        const foc = self.count_flameout()
-        if (0 != foc) {
-            return true
-        }
-        return false
-    }
-
-    fn maybe_stage(self) -> Unit = {
-        if (self.stage_needed())
-            self.common.vessel.staging.next()
     }
 }

--- a/tinker.to2
+++ b/tinker.to2
@@ -27,26 +27,16 @@ pub struct TinkerMission(common: Common) {
 }
 
 impl TinkerMission {
-    fn add(self, task: fn() -> float) -> Unit = {
-        self.common.sequencer.add(task)
+
+    sync fn next_seq(self, task: fn() -> float) -> Unit = {
+        self.common.next_seq(task)
     }
-    fn run(self) -> Unit = {
-        while (true) {
-            let r = self.common.sequencer.step()
-            if (r <= 0.0)
-                break
+    sync fn run_at(self, eta: float, name: string, task: fn() -> float) -> Unit = {
+        self.common.run_at(eta, name, task)
+    }
 
-            // As of KontrolSystem 0.2.2, I see no way to
-            // provide indirect execution of ASYNC methods,
-            // so the call chain from the main sequencer loop
-            // down to vessel.staging.next() has to be just
-            // normal explicit calls.
-            //
-            // See issue #20 in Farsyte/to2local for my plans.
-
-            self.stager.maybe_stage()       // staging is ASYNC
-            yield()
-        }
+    fn loop(self) -> Unit = {
+        self.common.loop()
     }
 }
 
@@ -97,12 +87,14 @@ pub fn main_flight( vessel: Vessel, target_apoapsis: float = 80000.0, heading: f
     // mission plan after initial construction, possibly even
     // during execution.
 
-    mission.add(fn () -> mission.launch.manual())
-    mission.add(fn () -> mission.launch.liftoff())
-    mission.add(fn () -> mission.ascent.gravityturn())
-    mission.add(fn () -> mission.ascent.spacecoast())
-    mission.add(fn () -> mission.orbital.circ_ap())
+    mission.next_seq(fn () -> mission.launch.manual())
+    mission.next_seq(fn () -> mission.launch.liftoff())
+    mission.next_seq(fn () -> mission.ascent.gravityturn())
+    mission.next_seq(fn () -> mission.ascent.spacecoast())
+    mission.next_seq(fn () -> mission.orbital.circ_ap())
 
-    mission.run()
+    mission.run_at(1.0, "stage", fn () -> mission.stager.stage_check())
+
+    mission.loop()
     CONSOLE.print_line("mission plan complete")
 }


### PR DESCRIPTION
Fixes #20

ok, so a bit of a major whack.

Deep down in mission.common.sequencer.scheduler we now have a
flag indicating that we want to stage. This flag can be set by mission
code in a SYNC function (so it can be scheduled), and the scheduler
knows to look at it and trigger the ASYNC stage call when needed.

with this in place, we can now allow the Scheduler to handle
looping, triggering the Sequencer to run the mission phases.